### PR TITLE
Fix plugin name in code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "homebridge";
 import { KeyLightBody, KeyLightAccessory } from "./types";
 
-const PLUGIN_NAME = "homebridge-key-light";
+const PLUGIN_NAME = "@nextcart/homebridge-key-light";
 const PLATFORM_NAME = "key-light";
 
 let hap: HAP;


### PR DESCRIPTION
Otherwise, this causes a bunch of these errors:
```
0|homebrid | [9/8/2020, 10:14:02 PM] A platform configured a new accessory under the plugin name 'homebridge-key-light'. However no loaded plugin could be found for the name!
```